### PR TITLE
✨⚙🚧 【新規】aru-4-2 ユーザー機能実装 docker DB導入と設定ファイル微修正

### DIFF
--- a/.project
+++ b/.project
@@ -17,4 +17,14 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1678034851469</id>
+			<name>container/postgres/log</name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
eclipseがワークスペースのリフレッシュを繰り返すようになった
dockerコンテナで作成したPostgreSqlのlog出力のマウント先を
プロジェクト配下のフォルダにしたことによるっぽい。

それでなぜリフレッシュされるのかはわからないけれど。。。

とりあえず、解決方法としては、
log出力先をプロジェクト配下外にするか(相対パス指定で上位を指定する)
リソースフィルターを設定するか

開発資材は、ひとまずプロジェクト配下で一括で管理したいので、リソースフィルターを設定してみる